### PR TITLE
情報エリア修正(2020.7.1)

### DIFF
--- a/OC/class.html
+++ b/OC/class.html
@@ -329,6 +329,12 @@
                 <br>データベース基礎
                 <br>コンピュータネットワーク基礎
                 <br>人工知能基礎</td>
+            <td bgcolor="#FFFAF0" align="middle"></td>
+            <td bgcolor="#FFFAF0" align="middle"></td>
+            
+          </tr>
+          <tr>
+            <td bgcolor="#FFFAF0" align="middle">
             <td bgcolor="#FFFAF0" valign="top" colspan="3">
               　<br>システム分析・設計基礎演習
               　<br>データ構造とアルゴリズム
@@ -341,11 +347,18 @@
               　<br>情報科学総合演習A</td>
                        
           </tr>
+          
           <tr>
             <td bgcolor="#FFFAF0" align="middle"></td>
             <td bgcolor="#FFFAF0" align="middle"></td>
-            <td bgcolor="#FFFAF0" valign="top" colspan="2">数理代数Ⅰ
-                <br>ウェブ論
+            <td bgcolor="#FFFAF0" align="middle">数理代数Ⅰ</td>
+            <td bgcolor="#FFFAF0" align="middle"></td>
+          </tr>
+          
+          <tr>
+            <td bgcolor="#FFFAF0" align="middle"></td>
+            <td bgcolor="#FFFAF0" align="middle"></td>
+            <td bgcolor="#FFFAF0" valign="top" colspan="2">ウェブ論
                 <br>情報システム計画
                 <br>情報システム演習
                 <br>インフラ構築演習


### PR DESCRIPTION
・3,4年次履修可能科目の改行
・「数理代数Ⅰ」を3年次のみ履修可の行に移動