### PR TITLE
社会エリア科目修正(2020.7.1)

### DIFF
--- a/OC/class.html
+++ b/OC/class.html
@@ -279,10 +279,19 @@
               <font color="#FFFFFF">4年次</font>
             </th>
           </tr>
-  
-  
+ 
+          
           <tr>
             <td bgcolor="khaki" align="middle" rowspan="2">（社会）</td>
+            <td bgcolor="#FFFAF0" align="middle"></td>
+            <td bgcolor="#FFFAF0" valign="top" colspan="2">経済数学
+                <br>現象の数理
+                <br>社会数理Ⅲ
+            </td>
+            <td bgcolor="#FFFAF0" align="middle"></td>
+          </tr>
+          
+          <tr>
             <td bgcolor="#FFFAF0" align="middle"></td>
             <td bgcolor="#FFFAF0" valign="top" colspan="3">マクロ経済学Ⅰ
                 <br>ミクロ経済学Ⅰ
@@ -295,20 +304,18 @@
                 <br>経営分析
                 <br>経営戦略論
                 <br>金融論
-                <br>現象の数理
                 <br>経済数学
                 <br>社会調査法Ⅱ
-                <br>公共経済学
                 <br>現代社会論</td>
           </tr>
+          
           <tr>
             <td bgcolor="#FFFAF0" align="middle"></td>
             <td bgcolor="#FFFAF0" align="middle"></td>
-            <td bgcolor="#FFFAF0" valign="top" colspan="2">マクロ経済政策
-                <br>資源循環論
+            <td bgcolor="#FFFAF0" valign="top" colspan="2">資源循環論
                 <br>経済政策
                 <br>公共経済学
-                <br>計量経済学I
+                <br>計量経済学Ⅰ
                 <br>計量経済学Ⅱ
                 <br>経営分析
                 <br>国際金融論
@@ -317,7 +324,7 @@
                 <br>コーポレートガバナンス
                 <br>インベストメント
                 <br>デリバティブズ
-                <br>環境経済学</td>
+                <br>環境経済論</td>
           </tr>
   
   


### PR DESCRIPTION
・公共経済学を3,4年次履修可能科目に訂正
・2,3年次履修可能科目の行を設け、そこに経済数学,現象の数理,社会数理Ⅲを移動
・マクロ経済政策の削除
・誤字訂正→　①計量経済学「I」　②環境経済「論」